### PR TITLE
Rename project branding to Vinted Sniper

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -629,7 +629,7 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Vinted-Notifications, a simple bot to monitor desired queries on Vinted.
+    Vinted Sniper, a simple bot to monitor desired queries on Vinted.
     Copyright (C) 2024 Fuyumi S.
 
     This program is free software: you can redistribute it and/or modify

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Vinted-Notifications
+# Vinted Sniper
 
 A real-time notification system for Vinted listings that works across all Vinted country domains. Get instant alerts
 when items matching your search criteria are posted.
 
-![Vinted-Notifications](https://github.com/user-attachments/assets/f2788511-5a8a-4a8d-8198-a4135081a3d8)
+![Vinted Sniper](https://github.com/user-attachments/assets/f2788511-5a8a-4a8d-8198-a4135081a3d8)
 
 ## 📋 Features
 
@@ -27,11 +27,11 @@ when items matching your search criteria are posted.
 1. **Clone the repository or download the latest release**
 
    ```bash
-   git clone https://github.com/Fuyucch1/Vinted-Notifications.git
-   cd Vinted-Notifications
+   git clone https://github.com/Fuyucch1/VintedSniper.git
+   cd VintedSniper
    ```
 
-   Alternatively, download the [latest release](https://github.com/Fuyucch1/Vinted-Notifications/releases/latest) and
+   Alternatively, download the [latest release](https://github.com/Fuyucch1/VintedSniper/releases/latest) and
    extract it.
 
 2. **Install dependencies**
@@ -121,7 +121,7 @@ MESSAGE = '''\
 
 ## 🔄 Updating
 
-1. Download the latest [release](https://github.com/Fuyucch1/Vinted-Notifications/releases/latest)
+1. Download the latest [release](https://github.com/Fuyucch1/VintedSniper/releases/latest)
 2. Back up your `vinted_notifications.db` file
 3. Replace all files with the new ones
 4. Restart the application

--- a/initial_db.sql
+++ b/initial_db.sql
@@ -58,7 +58,7 @@ VALUES ('telegram_enabled', 'True'),
        ('rss_process_running', 'False'),
 
        ('version', '1.0.4'),
-       ('github_url', 'https://github.com/Fuyucch1/Vinted-Notifications'),
+       ('github_url', 'https://github.com/Fuyucch1/VintedSniper'),
 
        ('items_per_query', '20'),
        ('query_refresh_delay', '60'),

--- a/rss_feed_plugin/rss_feed.py
+++ b/rss_feed_plugin/rss_feed.py
@@ -16,7 +16,7 @@ class RSSFeed:
 
         # Initialize feed generator
         self.fg = FeedGenerator()
-        self.fg.title('Vinted Notifications')
+        self.fg.title('Vinted Sniper')
         self.fg.description('Latest items from Vinted matching your search queries')
         self.fg.link(href=f'http://localhost:{db.get_parameter("rss_port")}')
         self.fg.language('en')

--- a/telegram_bot_plugin/telegram_bot.py
+++ b/telegram_bot_plugin/telegram_bot.py
@@ -11,7 +11,7 @@ async def hello(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     try:
         ver = db.get_parameter("version")
         await update.message.reply_text(
-            f'Hello {update.effective_user.first_name}! Vinted-Notifications is running under version {ver}.\n')
+            f'Hello {update.effective_user.first_name}! Vinted Sniper is running under version {ver}.\n')
     except Exception as e:
         logger.error(f"Error in hello command: {str(e)}", exc_info=True)
         try:

--- a/web_ui_plugin/static/css/custom.css
+++ b/web_ui_plugin/static/css/custom.css
@@ -1,4 +1,4 @@
-/* Custom styles for Vinted Notifications Web UI - Vinted-inspired theme */
+/* Custom styles for Vinted Sniper Web UI - Vinted-inspired theme */
 
 /* Global styles */
 :root {

--- a/web_ui_plugin/templates/allowlist.html
+++ b/web_ui_plugin/templates/allowlist.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Allowlist - Vinted Notifications{% endblock %}
+{% block title %}Allowlist - Vinted Sniper{% endblock %}
 
 {% block content %}
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">

--- a/web_ui_plugin/templates/base.html
+++ b/web_ui_plugin/templates/base.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}Vinted Notifications{% endblock %}</title>
+    <title>{% block title %}Vinted Sniper{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
@@ -143,7 +143,7 @@
 <header class="navbar navbar-dark sticky-top app-header flex-md-nowrap p-0 shadow">
     <div class="container-fluid">
         <a class="navbar-brand col-md-2 col-lg-2 me-0" href="/">
-            <i class="bi bi-bell-fill me-2"></i>Vinted Notifications
+            <i class="bi bi-bell-fill me-2"></i>Vinted Sniper
         </a>
         <button class="navbar-toggler position-absolute d-md-none collapsed" type="button" data-bs-toggle="collapse"
                 data-bs-target="#sidebarMenu" aria-controls="sidebarMenu" aria-expanded="false"
@@ -235,12 +235,12 @@
             <div class="col-md-4">
                 <p class="mb-1 d-flex align-items-center">
                     <i class="bi bi-bell-fill me-2 text-info"></i>
-                    <strong class="text-info">Vinted Notifications</strong>
+                    <strong class="text-info">Vinted Sniper</strong>
                     <span class="badge bg-secondary ms-2">v{{ current_version }}</span>
                 </p>
                 <p class="text-muted small mb-0">
                     &copy; {{ current_year }} <a href="{{ github_url }}" target="_blank"
-                                                 class="text-decoration-none text-info">Vinted Notifications</a>
+                                                 class="text-decoration-none text-info">Vinted Sniper</a>
                 </p>
             </div>
             <div class="col-md-4 text-center d-flex flex-column justify-content-center h-100">

--- a/web_ui_plugin/templates/config.html
+++ b/web_ui_plugin/templates/config.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Configuration - Vinted Notifications{% endblock %}
+{% block title %}Configuration - Vinted Sniper{% endblock %}
 
 {% block content %}
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">

--- a/web_ui_plugin/templates/index.html
+++ b/web_ui_plugin/templates/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Dashboard - Vinted Notifications{% endblock %}
+{% block title %}Dashboard - Vinted Sniper{% endblock %}
 
 {% block content %}
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">

--- a/web_ui_plugin/templates/items.html
+++ b/web_ui_plugin/templates/items.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Items - Vinted Notifications{% endblock %}
+{% block title %}Items - Vinted Sniper{% endblock %}
 
 {% block content %}
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">

--- a/web_ui_plugin/templates/logs.html
+++ b/web_ui_plugin/templates/logs.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Logs - Vinted Notifications{% endblock %}
+{% block title %}Logs - Vinted Sniper{% endblock %}
 
 {% block head %}
 <style>

--- a/web_ui_plugin/templates/queries.html
+++ b/web_ui_plugin/templates/queries.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Queries - Vinted Notifications{% endblock %}
+{% block title %}Queries - Vinted Sniper{% endblock %}
 
 {% block content %}
 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">


### PR DESCRIPTION
## Summary
- rebrand the UI and RSS feed titles from "Vinted Notifications" to "Vinted Sniper"
- update README, database defaults, Telegram message, and license notice to use the new Vinted Sniper name
- refresh GitHub links to point at the VintedSniper repository

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c92ab19b7c832f84d29ad349134440